### PR TITLE
Add ubuntu 18, init submodules

### DIFF
--- a/build-gnuradio.sh
+++ b/build-gnuradio.sh
@@ -588,13 +588,14 @@ function prereqs {
 			PKGLIST="libqwt6 libfontconfig1-dev libxrender-dev libpulse-dev swig g++
 			automake autoconf libtool python-dev libfftw3-dev
 			libcppunit-dev libboost-all-dev libusb-dev libusb-1.0-0-dev fort77
-			libsdl1.2-dev python-wxgtk2.8 git-core
+			libsdl1.2-dev git-core
 			libqt4-dev python-numpy ccache python-opengl libgsl0-dev
 			python-cheetah python-mako python-lxml doxygen qt4-default qt4-dev-tools libusb-1.0-0-dev
-			libqwt5-qt4-dev libqwtplot3d-qt4-dev pyqt4-dev-tools python-qwt5-qt4
+			libqwt5-qt4-dev pyqt4-dev-tools python-qwt5-qt4
 			cmake git-core wget libxi-dev python-docutils gtk2-engines-pixbuf r-base-dev python-tk
-			liborc-0.4-0 liborc-0.4-dev libasound2-dev python-gtk2 libzmq libzmq-dev libzmq1 libzmq1-dev python-requests
-			python-sphinx comedi-dev python-zmq libncurses5 libncurses5-dev python-wxgtk3.0 python-setuptools"
+			liborc-0.4-0 liborc-0.4-dev libasound2-dev python-gtk2 libzmq python-requests
+			python-sphinx comedi-dev python-zmq libncurses5 libncurses5-dev python-wxgtk3.0 python-setuptools
+			libcanberra-gtk-module"
 			CMAKE_FLAG1=-DPythonLibs_FIND_VERSION:STRING="2.7"
 			CMAKE_FLAG2=-DPythonInterp_FIND_VERSION:STRING="2.7"
 			;;

--- a/build-gnuradio.sh
+++ b/build-gnuradio.sh
@@ -584,6 +584,21 @@ function prereqs {
 		sudo apt-get -y purge 'libgnuradio*' >>$LOGDEV 2>&1
 		sudo apt-get -y purge 'python-gnuradio*' >>$LOGDEV 2>&1
 		case `grep DISTRIB_RELEASE /etc/lsb-release` in
+		*18.*)
+			PKGLIST="libqwt6 libfontconfig1-dev libxrender-dev libpulse-dev swig g++
+			automake autoconf libtool python-dev libfftw3-dev
+			libcppunit-dev libboost-all-dev libusb-dev libusb-1.0-0-dev fort77
+			libsdl1.2-dev python-wxgtk2.8 git-core
+			libqt4-dev python-numpy ccache python-opengl libgsl0-dev
+			python-cheetah python-mako python-lxml doxygen qt4-default qt4-dev-tools libusb-1.0-0-dev
+			libqwt5-qt4-dev libqwtplot3d-qt4-dev pyqt4-dev-tools python-qwt5-qt4
+			cmake git-core wget libxi-dev python-docutils gtk2-engines-pixbuf r-base-dev python-tk
+			liborc-0.4-0 liborc-0.4-dev libasound2-dev python-gtk2 libzmq libzmq-dev libzmq1 libzmq1-dev python-requests
+			python-sphinx comedi-dev python-zmq libncurses5 libncurses5-dev python-wxgtk3.0 python-setuptools"
+			CMAKE_FLAG1=-DPythonLibs_FIND_VERSION:STRING="2.7"
+			CMAKE_FLAG2=-DPythonInterp_FIND_VERSION:STRING="2.7"
+			;;
+
 		*15.*|*16.*)
 			PKGLIST="libqwt6 libfontconfig1-dev libxrender-dev libpulse-dev swig g++
 			automake autoconf libtool python-dev libfftw3-dev
@@ -795,6 +810,8 @@ function gitfetch {
 			RECURSE="--recursive"
 		fi
 		git clone --progress $RECURSE  https://github.com/gnuradio/gnuradio.git >>$LOGDEV 2>&1
+		git submodule init  >>$LOGDEV 2>&1
+		git submodule update >>$LOGDEV 2>&1
 		if [ ! -d gnuradio/gnuradio-core -a ! -d gnuradio/gnuradio-runtime ]
 		then
 			my_echo "Could not find gnuradio/gnuradio-{core,runtime} after GIT checkout"
@@ -810,6 +827,8 @@ function gitfetch {
 		then
 			cd gnuradio
 			git checkout maint >>$LOGDEV 2>&1
+		        git submodule init  >>$LOGDEV 2>&1
+		        git submodule update >>$LOGDEV 2>&1
 			cd $CWD
 		fi
 		


### PR DESCRIPTION
Updates the script to enable Ubuntu 18.*
Fixes an issue with submodules (VOLK) not being the correct version for the branch being installed.
Tested with Mint 19 and Ubuntu 18 building maint-3.7.   Ubuntu 18 has five unmet dependencies, but they apparently are not needed as it builds correctly.

